### PR TITLE
wait for 'close' event instead of 'exit' for children of mbpipe

### DIFF
--- a/bin/mbpipe
+++ b/bin/mbpipe
@@ -92,7 +92,7 @@ Step(
                                 child.stdin.end();
                                 child.stdout.on('data', stream);
                                 child.stderr.on('data', stream);
-                                child.on('exit', function(code) {
+                                child.on('close', function(code) {
                                     if (code) return callback(null, null);
                                     if (table === 'images') {
                                         mbtiles._db.run(


### PR DESCRIPTION
This way, it waits for all the actual data from a child process, not
just when the child closes.

when using mbpipe in practice, I tend to run into issues where some tiles in the modified dataset are empty. This solves that issue.

may be related to https://github.com/mapbox/node-mbtiles/issues/9
