### PR TITLE
Use unlinkSync consistently in tests

### DIFF
--- a/test/info.test.js
+++ b/test/info.test.js
@@ -9,7 +9,7 @@ var fixtures = {
     empty: __dirname + '/fixtures/empty.mbtiles'
 };
 
-try { fs.unlink(fixtures.empty); } catch (err) {}
+try { fs.unlinkSync(fixtures.empty); } catch (err) {}
 
 
 exports['get metadata'] = function(beforeExit, assert) {

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -8,7 +8,7 @@ var fixtures = {
     doesnotexist: __dirname + '/doesnotexist'
 };
 
-try { fs.unlink(fixtures.doesnotexist); } catch (err) {}
+try { fs.unlinkSync(fixtures.doesnotexist); } catch (err) {}
 
 
 exports['list'] = function(beforeExit, assert) {

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -13,7 +13,7 @@ var fixtures = {
     corrupt: __dirname + '/fixtures/corrupt.mbtiles'
 };
 
-try { fs.unlink(fixtures.non_existent); } catch (err) {}
+try { fs.unlinkSync(fixtures.non_existent); } catch (err) {}
 
 function yieldsError(assert, status, error, msg) {
     return function(err) {


### PR DESCRIPTION
Using unlink means that the exception may be thrown asynchronously and we will then fail to catch it and the test will abort.
