### PR TITLE
Added Windows support. Tests now pass on Windows.

### DIFF
--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -25,32 +25,56 @@ MBTiles.utils = require('./utils');
 MBTiles.schema = fs.readFileSync(__dirname + '/schema.sql', 'utf8');
 
 // Provides access to an mbtiles database file.
-// - uri: A parsed URL hash, the only relevant part is `pathname`.
+// - options: 
+//      - A string of the file path.
+//      - Or a parsed URL hash, the relevant parts are `pathname` and
+//        an optional query string for the batch size.
+//      - Or an object:
+//          {path: '/path/to/file.mbtiles', batchSize: 100 (optional) }
+//
 // - callback: Will be called when the resources have been acquired
-//       or acquisition failed.
+//             or acquisition failed.
 require('util').inherits(MBTiles, require('events').EventEmitter)
-function MBTiles(uri, callback) {
-    if (typeof uri === 'string') uri = url.parse(uri, true);
-    else if (typeof uri.query === 'string') uri.query = qs.parse(uri.query);
-
-    if (!uri.pathname) {
-        callback(new Error('Invalid URI ' + url.format(uri)));
-        return;
+function MBTiles(options, callback) {
+    this._batchSize = 100;
+    if (typeof options === 'string') {
+        var parsed = url.parse(options, true);
+        // only use the parsed url if it has a batch query string
+        if (parsed.query.batch) {
+            this.filename = parsed.pathname;
+            this._batchSize = +parsed.query.batch;
+        }
+        else {
+            // otherwise just use the url and let sqlite
+            // decide if it can handle it
+            this.filename = options;
+        }
     }
-
-    if (uri.hostname === '.' || uri.hostname == '..') {
-        uri.pathname = uri.hostname + uri.pathname;
-        delete uri.hostname;
-        delete uri.host;
+    else if (typeof options === 'object') {
+        if (options.pathname) {
+            if (options.hostname === '.' || options.hostname == '..') {
+                this.filename = options.hostname + options.pathname;
+            }
+            else {
+                this.filename = options.pathname;
+            }
+            if (typeof options.query === 'string') {
+                options.query = qs.parse(options.query);
+            }
+            this._batchSize = +options.query.batch || this._batchSize;
+        }
+        else {
+            this.filename = options.path;
+            this._batchSize = +options.batchSize || this._batchSize;
+        }
     }
-    uri.query = uri.query || {};
-    if (!uri.query.batch) uri.query.batch = 100;
+    if (!this.filename) {
+        callback(new Error('Invalid options. Could not determine file location.'));
+    }
 
     var mbtiles = this;
     this.setMaxListeners(0);
-    this.filename = uri.pathname;
-    this._batchSize = +uri.query.batch;
-    mbtiles._db = new sqlite3.Database(mbtiles.filename, function(err) {
+    mbtiles._db = new sqlite3.Database(this.filename, function(err) {
         if (err) return callback(err);
         fs.stat(mbtiles.filename, function(err, stat) {
             if (err) return callback(err);


### PR DESCRIPTION
Added windows file path support.
Added constructor options to set batch size without using a query
string.
Still works as previous version did. You can still pass a URL object or
a URL string.
