### PR TITLE
Smaller batch size

### DIFF
--- a/lib/zxystream.js
+++ b/lib/zxystream.js
@@ -9,7 +9,7 @@ util.inherits(ZXYStream, stream.Readable);
 //
 // The `batch` option exists to allow tests to check that
 // multiple calls to `_read` are handled properly. IRL the
-// default offset of 10000 should be reasonably efficient
+// default offset of 1000 should be reasonably efficient
 // and not worth messing with.
 function ZXYStream(source, options) {
     if (!source) throw new TypeError('MBTiles source required');
@@ -20,7 +20,7 @@ function ZXYStream(source, options) {
         throw new TypeError('options.batch must be a positive integer');
 
     this.source = source;
-    this.batch = options.batch || 10000;
+    this.batch = options.batch || 1000;
     this.offset = 0;
 
     stream.Readable.call(this);

--- a/test/zxystream.js
+++ b/test/zxystream.js
@@ -16,7 +16,7 @@ tape('zxystream default batch', function(assert) {
     var called = 0;
 
     assert.deepEqual(stream.source, source, 'sets stream.source');
-    assert.deepEqual(stream.batch, 10000, 'sets stream.batch = 10000');
+    assert.deepEqual(stream.batch, 1000, 'sets stream.batch = 1000');
     assert.deepEqual(stream.offset, 0, 'sets stream.offset = 0');
 
     stream.on('data', function(lines) {


### PR DESCRIPTION
Setting a more reasonable batch size to prevent some downstream applications from choking on too big a batch.

![](http://cdn.shopify.com/s/files/1/0100/5392/products/TempletonRyeSpiritsRyeFront900_grande.jpg?v=1399572211)
