### PR TITLE
Query from `map` table with more than one index.

### DIFF
--- a/lib/zxystream.js
+++ b/lib/zxystream.js
@@ -33,7 +33,7 @@ ZXYStream.prototype._read = function() {
     if (!stream.table) {
         return this.source._db.get("select count(1) as count from sqlite_master where type = 'index' and tbl_name = 'map';", function(err, row) {
             if (err) return stream.emit('error', err);
-            stream.table = row.count === 1 ? 'map' : 'tiles';
+            stream.table = row.count >= 1 ? 'map' : 'tiles';
             return stream._read();
         });
     }


### PR DESCRIPTION
mbtiles files often have two indexes on the map table. This doesn't
impact our ability to do an optimized query against it for ZXYStream.
