### PR TITLE
Error handling in async loop

### DIFF
--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -31,7 +31,7 @@ MBTiles.schema = fs.readFileSync(__dirname + '/schema.sql', 'utf8');
 // - callback: Will be called when the resources have been acquired
 //       or acquisition failed.
 require('util').inherits(MBTiles, require('events').EventEmitter)
-function MBTiles(uri, callback) {    
+function MBTiles(uri, callback) {
     if (typeof uri === 'string') {
         uri = url.parse(uri, true);
         uri.pathname = qs.unescape(uri.pathname);
@@ -274,17 +274,29 @@ MBTiles.prototype.getInfo = function(callback) {
         var zooms = [];
         var query = mbtiles._db.prepare('SELECT zoom_level FROM tiles WHERE zoom_level = ? LIMIT 1', function(err) {
             if (err) return callback(err.errno === 1 ? null : err, info);
-            for (var i = 0; i < remaining; i++) query.get(i, function(err, row) {
-                if (err) return (remaining = 0) && callback(err);
-                if (row) zooms.push(row.zoom_level);
-                if (--remaining === 0) {
-                    if (!zooms.length) return callback(null, info);
-                    zooms.sort(function(a,b) { return a < b ? -1 : 1 });
-                    info.minzoom = zooms[0];
-                    info.maxzoom = zooms.pop();
-                    return callback(null, info);
-                }
-            });
+
+            function done(err, info) {
+                if (done.sent) return;
+                callback(err, info);
+                done.sent = true;
+            }
+
+            done.sent = false;
+
+            for (var i = 0; i < remaining; i++) {
+                query.get(i, function(err, row) {
+                    if (err) return done(err);
+                    if (row) zooms.push(row.zoom_level);
+                    if (--remaining === 0) {
+                        if (!zooms.length) return callback(null, info);
+                        zooms.sort(function(a,b) { return a < b ? -1 : 1; });
+                        info.minzoom = zooms[0];
+                        info.maxzoom = zooms.pop();
+                        return done(null, info);
+                    }
+                });
+            }
+
             query.finalize();
         });
     };
@@ -752,4 +764,3 @@ MBTiles.prototype.geocoderCentroid = function(id, zxy, callback) {
 MBTiles.prototype.createZXYStream = function(options) {
     return new ZXYStream(this, options);
 };
-


### PR DESCRIPTION
A logic error [here](https://github.com/mapbox/node-mbtiles/blob/master/lib/mbtiles.js#L278) led to a condition where the callback function would never fire. `(remaining = 0)` returns `0`, which is falsey.

Not sure if this is the best pattern in the world, but here's another tactic to erroring out of the `for` loop while making async calls. This passes tests and fixes my situation.