### PR TITLE
Add a length method to zxystream

### DIFF
--- a/lib/zxystream.js
+++ b/lib/zxystream.js
@@ -63,9 +63,15 @@ ZXYStream.prototype._read = function() {
     }
 };
 
+ZXYStream.prototype.length = function(callback) {
+    this.source._db.get('select count(1) as count from map;', function(err, row) {
+        if (err) return callback(err);
+        callback(null, Number(row.count));
+    });
+};
+
 function toLine(row) {
     // Flip Y coordinate because MBTiles files are TMS.
     var y = row.y = (1 << row.z) - 1 - row.y;
     return row.z + '/' + row.x + '/' + y + '\n';
 }
-

--- a/test/zxystream.js
+++ b/test/zxystream.js
@@ -73,6 +73,15 @@ tape('zxystream batch = 10', function(assert) {
     });
 });
 
+tape('zxystream length attribute', function(assert) {
+    var stream = source.createZXYStream();
+    stream.length(function(err, length) {
+        assert.ifError(err, 'no error');
+        assert.equal(length, 269, 'expected length');
+        assert.end();
+    });
+});
+
 tape('zxystream unindexed', function(assert) {
     new MBTiles(__dirname + '/fixtures/unindexed.mbtiles', function(err, s) {
         assert.ifError(err);
@@ -112,7 +121,14 @@ tape('zxystream unindexed zxystream', function(assert) {
     });
 });
 
-
+tape('zxystream unindexed length attribute', function(assert) {
+    var stream = source.createZXYStream();
+    stream.length(function(err, length) {
+        assert.ifError(err, 'no error');
+        assert.equal(length, 285, 'expected length');
+        assert.end();
+    });
+});
 
 tape('zxystream empty', function(assert) {
     new MBTiles(__dirname + '/fixtures/non_existent.mbtiles', function(err, s) {
@@ -134,4 +150,11 @@ tape('zxystream empty zxystream', function(assert) {
     });
 });
 
-
+tape('zxystream nonexistent length attribute', function(assert) {
+    var stream = source.createZXYStream();
+    stream.length(function(err, length) {
+        assert.ok(err, 'expected error');
+        assert.equal(err.code, 'SQLITE_ERROR', 'expected error code from failed read');
+        assert.end();
+    });
+});


### PR DESCRIPTION
Has to be a method call since the zxystream constructor is sync and counting tiles is gonna be async. Also want to double-check with you @yhahn about what you think the best failure condition would be on a failed read. Currently just passes through the sqlite error, [see this test](https://github.com/mapbox/node-mbtiles/blob/c3b2799476c08efae5015387bb75aac893496a97/test/zxystream.js#L153-L160).

Fixes #52 
