### PR TITLE
Finalize prepared statement in zxystream

### DIFF
--- a/lib/zxystream.js
+++ b/lib/zxystream.js
@@ -57,7 +57,11 @@ ZXYStream.prototype._read = function() {
             if (error) {
                 stream.emit('error', error);
             } else {
-                stream.push(lines || null);
+                if (lines) stream.push(lines);
+                else {
+                    stream.statement.finalize();
+                    stream.push(null);
+                }
             }
         }
     }
@@ -68,4 +72,3 @@ function toLine(row) {
     var y = row.y = (1 << row.z) - 1 - row.y;
     return row.z + '/' + row.x + '/' + y + '\n';
 }
-

--- a/test/zxystream.js
+++ b/test/zxystream.js
@@ -41,6 +41,18 @@ tape('zxystream default batch', function(assert) {
     });
 });
 
+tape('zxystream: can close source', function(assert) {
+    new MBTiles(__dirname + '/fixtures/plain_1.mbtiles', function(err, src) {
+        assert.ifError(err);
+        src.createZXYStream()
+            .on('end', function() {
+                src.close(function(err) {
+                    assert.ifError(err, 'can close source when zxystream is finished');
+                    assert.end();
+                });
+            }).resume();
+    });
+});
 
 tape('zxystream batch = 10', function(assert) {
     var stream = source.createZXYStream({batch:10});
@@ -133,5 +145,3 @@ tape('zxystream empty zxystream', function(assert) {
         assert.end();
     });
 });
-
-


### PR DESCRIPTION
I ran into this while trying to close an mbtiles source after a completed `tilelive.copy` operation. The close call would fail with errors like: 

```
Error: SQLITE_BUSY: unable to close due to unfinalized statements or unfinished backups
```

This PR simply finalizes the prepared statement before pushing `null` to the readable stream.

cc @yhahn 