### PR TITLE
Bump sqlite3 to 3.1, include node 4.1 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
 # track down segfaults per https://travis-ci.org/mapbox/node-mbtiles/jobs/36595376
 # - "0.11"
  - "0.10"
+ - "4.1"
 
 before_install:
  - true

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ],
     "dependencies": {
         "tiletype": "0.1.x",
-        "sqlite3": "~3.0.0",
+        "sqlite3": "~3.1.0",
         "sphericalmercator": "~1.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Following from https://github.com/mapbox/node-sqlite3/issues/487, bumping the sqlite3 dependency allows this to build on the latest node and iojs