### PR TITLE
Handle table not found error in getGeocoderData

### DIFF
--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -600,6 +600,7 @@ MBTiles.prototype.putInfo = function(data, callback) {
 // Implements carmen#getGeocoderData method.
 MBTiles.prototype.getGeocoderData = function(type, shard, callback) {
     return this._db.get('SELECT data FROM geocoder_data WHERE type = ? AND shard = ?', type, shard, function(err, row) {
+        if (err && err.code === 'SQLITE_ERROR' && err.errno === 1) return callback();
         if (err) return callback(err);
         if (!row) return callback();
         zlib.inflate(row.data, callback);

--- a/test/geocoder.test.js
+++ b/test/geocoder.test.js
@@ -13,12 +13,16 @@ var expected = {
 };
 
 var tmp = require('os').tmpdir() + '/mbtiles-test-' + (+new Date).toString(16);
+var tilesOnly;
 var index;
 var from;
 var to;
 
 try { fs.mkdirSync(tmp); } catch(err) { throw err; }
 
+tape('setup', function(assert) {
+    tilesOnly  = new MBTiles(tmp + '/tilesOnly.mbtiles', assert.end);
+});
 tape('setup', function(assert) {
     index = new MBTiles(__dirname + '/fixtures/geocoder_data.mbtiles', assert.end);
 });
@@ -33,6 +37,22 @@ tape('getGeocoderData', function(assert) {
     index.getGeocoderData('term', 0, function(err, buffer) {
         assert.ifError(err);
         assert.equal(3891, buffer.length);
+        assert.end();
+    });
+});
+
+tape('getGeocoderData (nodata)', function(assert) {
+    index.getGeocoderData('term', 1e6, function(err, buffer) {
+        assert.ifError(err);
+        assert.equal(buffer, undefined);
+        assert.end();
+    });
+});
+
+tape('getGeocoderData (no table)', function(assert) {
+    tilesOnly.getGeocoderData('term', 0, function(err, buffer) {
+        assert.ifError(err);
+        assert.equal(buffer, undefined);
         assert.end();
     });
 });
@@ -151,6 +171,7 @@ tape('cleanup', function(assert) {
             if (err) throw err;
             to.close(function(err) {
                 if (err) throw err;
+                try { fs.unlinkSync(tmp + '/tilesOnly.mbtiles'); } catch(err) { throw err; }
                 try { fs.unlinkSync(tmp + '/indexed.mbtiles'); } catch(err) { throw err; }
                 try { fs.rmdirSync(tmp); } catch(err) { throw err; }
                 assert.end();

--- a/test/geocoder.test.js
+++ b/test/geocoder.test.js
@@ -164,20 +164,14 @@ tape('geocoderCentroid USA', function(assert) {
     });
 });
 
+tape('cleanup', function(assert) { tilesOnly.close(assert.end); });
+tape('cleanup', function(assert) { index.close(assert.end); });
+tape('cleanup', function(assert) { from.close(assert.end); });
+tape('cleanup', function(assert) { to.close(assert.end); });
 tape('cleanup', function(assert) {
-    index.close(function(err) {
-        if (err) throw err;
-        from.close(function(err) {
-            if (err) throw err;
-            to.close(function(err) {
-                if (err) throw err;
-                try { fs.unlinkSync(tmp + '/tilesOnly.mbtiles'); } catch(err) { throw err; }
-                try { fs.unlinkSync(tmp + '/indexed.mbtiles'); } catch(err) { throw err; }
-                try { fs.rmdirSync(tmp); } catch(err) { throw err; }
-                assert.end();
-            });
-        });
-    });
+    try { fs.unlinkSync(tmp + '/tilesOnly.mbtiles'); } catch(err) { throw err; }
+    try { fs.unlinkSync(tmp + '/indexed.mbtiles'); } catch(err) { throw err; }
+    try { fs.rmdirSync(tmp); } catch(err) { throw err; }
+    assert.end();
 });
-
 


### PR DESCRIPTION
Robustifies `getGeocoderData` calls to not error when querying an MBTiles file without this table.