### PR TITLE
Geocoder data iterator

### DIFF
--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -9,6 +9,7 @@ var sm = new (require('sphericalmercator'));
 var sqlite3 = require('sqlite3');
 var tiletype = require('tiletype');
 var ZXYStream = require('./zxystream');
+var queue = require('d3-queue').queue;
 
 function noop(err) {
     if (err) throw err;
@@ -625,34 +626,42 @@ MBTiles.prototype.geocoderDataIterator = function(type) {
     var doneSentinel = {};
     var _this = this;
 
+    var zlibQueue = queue(1);
+    var inflate = function(data, callback) {
+        zlibQueue.defer(function(cb) {
+            zlib.inflate(data, function(err, buf) {
+                callback(err, buf);
+                cb();
+            });
+        });
+    }
+
     var sending = false;
     var sendIfAvailable = function() {
         if (sending) return;
         sending = true;
 
         while (nextQueue.length && dataQueue.length) {
-            var nextCb = nextQueue.shift(), data, cbValue;
+            var nextCb = nextQueue.shift(), data;
             if (dataQueue[0] == doneSentinel) {
-                cbValue = {
-                    err: null,
-                    row: {value: undefined, done: true}
-                }
+                (function(nextCb) {
+                    setImmediate(function() {
+                        nextCb(null, {value: undefined, done: true});
+                    });
+                })(nextCb);
             } else {
                 data = dataQueue.shift();
                 maybeRefillBuffer();
 
-                cbValue = {
-                    err: data.err,
-                    row: {value: {shard: data.row.shard, data: zlib.inflateSync(data.row.data)}, done: false}
-                };
+                (function(nextCb, cbValue) {
+                    inflate(data.row.data, function(err, buf) {
+                        nextCb(
+                            data.err,
+                            {value: {shard: data.row.shard, data: buf}, done: false}
+                        );
+                    })
+                })(nextCb, data);
             }
-            // bind the callback and data now so that they don't change before the setImmediate
-            // callback is executed
-            (function(nextCb, cbValue) {
-                setImmediate(function() {
-                    nextCb(cbValue.err, cbValue.row);
-                });
-            })(nextCb, cbValue);
         }
 
         sending = false;

--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -615,15 +615,64 @@ MBTiles.prototype.putGeocoderData = function(type, shard, data, callback) {
     });
 };
 
-// Implements carmen#getGeocoderData method.
-MBTiles.prototype.geocoderDataForEach = function(type, callback, completeCallback) {
-    return this._db.each('SELECT shard, data FROM geocoder_data WHERE type = ? ORDER BY shard', type, function(err, row) {
-        if (err && err.code === 'SQLITE_ERROR' && err.errno === 1) return callback();
-        if (err) return callback(err);
-        if (!row) return callback();
-        callback(row.shard, zlib.inflateSync(row.data));
-    }, completeCallback);
-};
+// Implements carmen#geocoderDataIterator method.
+MBTiles.prototype.geocoderDataIterator = function(type) {
+    var chunkSize = 100;
+    var position = 0;
+    var getNextIfBelow = 0.2 * chunkSize;
+    var nextQueue = [];
+    var dataQueue = [];
+    var doneSentinel = {};
+    var _this = this;
+
+    var sendIfAvailable = function() {
+        while (nextQueue.length && dataQueue.length) {
+            var nextCb = nextQueue.shift(), data;
+            if (dataQueue[0] == doneSentinel) {
+                nextCb({value: undefined, done: true});
+            } else {
+                data = dataQueue.shift();
+                maybeRefillBuffer();
+
+                nextCb({value: {shard: data.shard, data: zlib.inflateSync(data.data)}, done: false});
+            }
+        }
+    }
+
+    var refilling = false;
+    var refillBuffer = function() {
+        refilling = true;
+        var segmentCount = 0;
+        _this._db.each('SELECT shard, data FROM geocoder_data WHERE type = ? ORDER BY shard limit ?,?', type, position, chunkSize, function(err, row) {
+            dataQueue.push(row);
+            segmentCount += 1;
+            sendIfAvailable();
+        }, function() {
+            refilling = false;
+            if (segmentCount) {
+                maybeRefillBuffer();
+            } else {
+                // we didn't get anything this time, so we're done
+                dataQueue.push(doneSentinel);
+                sendIfAvailable();
+            }
+        });
+        position += chunkSize;
+    }
+
+    var maybeRefillBuffer = function() {
+        if (dataQueue.length <= getNextIfBelow && !refilling && dataQueue[dataQueue.length - 1] != doneSentinel) {
+            refillBuffer();
+        }
+    }
+
+    refillBuffer();
+
+    return {asyncNext: function(callback) {
+        nextQueue.push(callback);
+        sendIfAvailable();
+    }}
+}
 
 // Implements carmen#getIndexableDocs method.
 MBTiles.prototype.getIndexableDocs = function(pointer, callback) {

--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -615,6 +615,9 @@ MBTiles.prototype.putGeocoderData = function(type, shard, data, callback) {
     });
 };
 
+var stackCounter = 0;
+var stackMax = 10;
+
 // Implements carmen#geocoderDataIterator method.
 MBTiles.prototype.geocoderDataIterator = function(type) {
     var chunkSize = 100;
@@ -625,6 +628,20 @@ MBTiles.prototype.geocoderDataIterator = function(type) {
     var doneSentinel = {};
     var _this = this;
 
+    // every tenth callback call (globally) do it via setImmediate
+    // to avoid callback loops that blow the callstack
+    var checkStack = function(cb, arg) {
+        if (stackCounter >= stackMax) {
+            stackCounter = 0;
+            setImmediate(function() {
+                cb(arg);
+            })
+        } else {
+            stackCounter += 1;
+            cb(arg);
+        }
+    }
+
     var sending = false;
     var sendIfAvailable = function() {
         if (sending) return;
@@ -633,12 +650,12 @@ MBTiles.prototype.geocoderDataIterator = function(type) {
         while (nextQueue.length && dataQueue.length) {
             var nextCb = nextQueue.shift(), data;
             if (dataQueue[0] == doneSentinel) {
-                nextCb({value: undefined, done: true});
+                checkStack(nextCb, {value: undefined, done: true});
             } else {
                 data = dataQueue.shift();
                 maybeRefillBuffer();
 
-                nextCb({value: {shard: data.shard, data: zlib.inflateSync(data.data)}, done: false});
+                checkStack(nextCb, {value: {shard: data.shard, data: zlib.inflateSync(data.data)}, done: false});
             }
         }
 

--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -625,7 +625,11 @@ MBTiles.prototype.geocoderDataIterator = function(type) {
     var doneSentinel = {};
     var _this = this;
 
+    var sending = false;
     var sendIfAvailable = function() {
+        if (sending) return;
+        sending = true;
+
         while (nextQueue.length && dataQueue.length) {
             var nextCb = nextQueue.shift(), data;
             if (dataQueue[0] == doneSentinel) {
@@ -637,6 +641,8 @@ MBTiles.prototype.geocoderDataIterator = function(type) {
                 nextCb({value: {shard: data.shard, data: zlib.inflateSync(data.data)}, done: false});
             }
         }
+
+        sending = false;
     }
 
     var refilling = false;

--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -448,7 +448,6 @@ MBTiles.prototype._commit = function(callback) {
                 break;
             }
         });
-
         mbtiles._db.run('COMMIT', function(err) {
             mbtiles._committing = false;
             mbtiles.emit('commit');
@@ -614,6 +613,16 @@ MBTiles.prototype.putGeocoderData = function(type, shard, data, callback) {
         if (err) return callback(err);
         source.write('geocoder_data', type + '.' + shard, { type:type, shard: shard, data: zdata }, callback);
     });
+};
+
+// Implements carmen#getGeocoderData method.
+MBTiles.prototype.geocoderDataForEach = function(type, callback, completeCallback) {
+    return this._db.each('SELECT shard, data FROM geocoder_data WHERE type = ? ORDER BY shard', type, function(err, row) {
+        if (err && err.code === 'SQLITE_ERROR' && err.errno === 1) return callback();
+        if (err) return callback(err);
+        if (!row) return callback();
+        callback(row.shard, zlib.inflateSync(row.data));
+    }, completeCallback);
 };
 
 // Implements carmen#getIndexableDocs method.

--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -616,7 +616,7 @@ MBTiles.prototype.putGeocoderData = function(type, shard, data, callback) {
 };
 
 var stackCounter = 0;
-var stackMax = 10;
+var stackMax = 3;
 
 // Implements carmen#geocoderDataIterator method.
 MBTiles.prototype.geocoderDataIterator = function(type) {
@@ -628,7 +628,7 @@ MBTiles.prototype.geocoderDataIterator = function(type) {
     var doneSentinel = {};
     var _this = this;
 
-    // every tenth callback call (globally) do it via setImmediate
+    // every nth callback call (globally) do it via setImmediate
     // to avoid callback loops that blow the callstack
     var checkStack = function(cb, arg) {
         if (stackCounter >= stackMax) {

--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -615,9 +615,6 @@ MBTiles.prototype.putGeocoderData = function(type, shard, data, callback) {
     });
 };
 
-var stackCounter = 0;
-var stackMax = 3;
-
 // Implements carmen#geocoderDataIterator method.
 MBTiles.prototype.geocoderDataIterator = function(type) {
     var chunkSize = 100;
@@ -628,35 +625,28 @@ MBTiles.prototype.geocoderDataIterator = function(type) {
     var doneSentinel = {};
     var _this = this;
 
-    // every nth callback call (globally) do it via setImmediate
-    // to avoid callback loops that blow the callstack
-    var checkStack = function(cb, arg) {
-        if (stackCounter >= stackMax) {
-            stackCounter = 0;
-            setImmediate(function() {
-                cb(arg);
-            })
-        } else {
-            stackCounter += 1;
-            cb(arg);
-        }
-    }
-
     var sending = false;
     var sendIfAvailable = function() {
         if (sending) return;
         sending = true;
 
         while (nextQueue.length && dataQueue.length) {
-            var nextCb = nextQueue.shift(), data;
+            var nextCb = nextQueue.shift(), data, cbValue;
             if (dataQueue[0] == doneSentinel) {
-                checkStack(nextCb, {value: undefined, done: true});
+                cbValue = {value: undefined, done: true};
             } else {
                 data = dataQueue.shift();
                 maybeRefillBuffer();
 
-                checkStack(nextCb, {value: {shard: data.shard, data: zlib.inflateSync(data.data)}, done: false});
+                cbValue = {value: {shard: data.shard, data: zlib.inflateSync(data.data)}, done: false};
             }
+            // bind the callback and data now so that they don't change before the setImmediate
+            // callback is executed
+            (function(nextCb, cbValue) {
+                setImmediate(function() {
+                    nextCb(cbValue);
+                });
+            })(nextCb, cbValue);
         }
 
         sending = false;

--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -633,18 +633,24 @@ MBTiles.prototype.geocoderDataIterator = function(type) {
         while (nextQueue.length && dataQueue.length) {
             var nextCb = nextQueue.shift(), data, cbValue;
             if (dataQueue[0] == doneSentinel) {
-                cbValue = {value: undefined, done: true};
+                cbValue = {
+                    err: null,
+                    row: {value: undefined, done: true}
+                }
             } else {
                 data = dataQueue.shift();
                 maybeRefillBuffer();
 
-                cbValue = {value: {shard: data.shard, data: zlib.inflateSync(data.data)}, done: false};
+                cbValue = {
+                    err: data.err,
+                    row: {value: {shard: data.row.shard, data: zlib.inflateSync(data.row.data)}, done: false}
+                };
             }
             // bind the callback and data now so that they don't change before the setImmediate
             // callback is executed
             (function(nextCb, cbValue) {
                 setImmediate(function() {
-                    nextCb(cbValue);
+                    nextCb(cbValue.err, cbValue.row);
                 });
             })(nextCb, cbValue);
         }
@@ -657,7 +663,7 @@ MBTiles.prototype.geocoderDataIterator = function(type) {
         refilling = true;
         var segmentCount = 0;
         _this._db.each('SELECT shard, data FROM geocoder_data WHERE type = ? ORDER BY shard limit ?,?', type, position, chunkSize, function(err, row) {
-            dataQueue.push(row);
+            dataQueue.push({row: row, err: err});
             segmentCount += 1;
             sendIfAvailable();
         }, function() {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "Konstantin Käfer <kkaefer>"
   ],
   "dependencies": {
+    "d3-queue": "~2.0.3",
     "tiletype": "0.1.x",
     "sqlite3": "3.x",
     "sphericalmercator": "~1.0.1"

--- a/test/geocoder.test.js
+++ b/test/geocoder.test.js
@@ -80,7 +80,8 @@ tape('putGeocoderData', function(assert) {
 tape('geocoderDataIterator', function(assert) {
     var it = to.geocoderDataIterator("term");
     var data = [];
-    var n = function(item) {
+    var n = function(err, item) {
+        assert.ifError(err);
         if (item.done) {
             assert.equal(data.length, 2, "iterator produces two shards");
 


### PR DESCRIPTION
Adds a way of iterating over geocoder shards and data in order, to support merging of carmen indexes.

cc @yhahn 