### PR TITLE
Use 'xyz' as scheme in metadata

### DIFF
--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -224,7 +224,6 @@ MBTiles.prototype.getInfo = function(callback) {
 
     var mbtiles = this;
     var info = {};
-    info.scheme = 'xyz';
     info.basename = path.basename(mbtiles.filename);
     info.id = path.basename(mbtiles.filename, path.extname(mbtiles.filename));
     info.filesize = mbtiles._stat.size;
@@ -257,6 +256,10 @@ MBTiles.prototype.getInfo = function(callback) {
                 break;
             }
         });
+        
+        // Guarantee that we always return proper schema type, even if 'tms' is specified in metadata
+        info.scheme = 'xyz';
+        
         ensureZooms(info, function(err, info) {
             if (err) return callback(err);
             ensureBounds(info, function(err, info) {

--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -224,7 +224,7 @@ MBTiles.prototype.getInfo = function(callback) {
 
     var mbtiles = this;
     var info = {};
-    info.scheme = 'tms';
+    info.scheme = 'xyz';
     info.basename = path.basename(mbtiles.filename);
     info.id = path.basename(mbtiles.filename, path.extname(mbtiles.filename));
     info.filesize = mbtiles._stat.size;

--- a/test/info.test.js
+++ b/test/info.test.js
@@ -21,7 +21,7 @@ tape('get metadata', function(assert) {
                 name: 'plain_1',
                 description: 'demo description',
                 version: '1.0.3',
-                scheme: 'tms',
+                scheme: 'xyz',
                 minzoom: 0,
                 maxzoom: 4,
                 formatter: null,
@@ -57,7 +57,7 @@ tape('get/put metadata from empty file', function(assert) {
                 basename: "empty.mbtiles",
                 filesize: 0,
                 id: "empty",
-                scheme: "tms"
+                scheme: "xyz"
             }, data);
 
             mbtiles.putInfo(info, function(err) {
@@ -80,7 +80,7 @@ tape('get/put metadata from empty file', function(assert) {
                                     basename: "empty.mbtiles",
                                     filesize: 0,
                                     id: "empty",
-                                    scheme: "tms",
+                                    scheme: "xyz",
                                     version: "1.0.0",
                                     level1: { level2: "property" },
                                     custom: [ 'custom list' ]


### PR DESCRIPTION
As getTile swaps the z-coordinate from tms to xyz

Fixes #65 
