### PR TITLE
Update to @mapbox namespaced modules

### DIFF
--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -5,9 +5,9 @@ var path = require('path');
 var url = require('url');
 var qs = require('querystring');
 var Buffer = require('buffer').Buffer;
-var sm = new (require('sphericalmercator'));
+var sm = new (require('@mapbox/sphericalmercator'));
 var sqlite3 = require('sqlite3');
-var tiletype = require('tiletype');
+var tiletype = require('@mapbox/tiletype');
 var ZXYStream = require('./zxystream');
 var queue = require('d3-queue').queue;
 

--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
     "Dane Springmeyer <springmeyer>",
     "Young Hahn <yhahn>",
     "Konstantin Käfer <kkaefer>",
-    "Andrew Pendleton <apendleton>"
+    "Andrew Pendleton <apendleton>",
+    "Kai Dalgleish <kaibot3000>"
   ],
   "dependencies": {
     "d3-queue": "~2.0.3",
-    "tiletype": "0.1.x",
+    "@mapbox/tiletype": "0.3.x",
     "sqlite3": "3.x",
-    "sphericalmercator": "~1.0.1"
+    "@mapbox/sphericalmercator": "~1.0.1"
   },
   "devDependencies": {
     "tape": "~3.0.0",


### PR DESCRIPTION
Part of the continuing [battle for warning-free installs](https://github.com/mapbox/api-geocoder/issues/1303)

- Updates `sphericalmercator` to `@mapbox/sphericalmercator`
- Updates `tiletype` as above and also bumps version to namespaced `0.3.x`

Tests pass locally 👍 
