### PR TITLE
maxTiles killswitch within ZXYStream

### DIFF
--- a/lib/zxystream.js
+++ b/lib/zxystream.js
@@ -14,6 +14,10 @@ function ZXYStream(source, options) {
     this.source = source;
     this.batch = options.batch || 1000;
 
+    // max tiles used to end a stream early
+    this.maxTilesCount = 1;
+    this.maxTiles = options.maxTiles || Infinity;
+
     stream.Readable.call(this);
 }
 
@@ -44,9 +48,11 @@ ZXYStream.prototype._read = function() {
     var lines = '';
     var error;
     var remaining = stream.batch;
+
     for (var i = 0; i < stream.batch; i++) stream.statement.get(afterGet);
 
     function afterGet(err, row) {
+        stream.maxTilesCount++;
         if (err && err.code === 'SQLITE_ERROR' && /no such table/.test(err.message)) {
             // no-op
         } else if (err) {
@@ -56,12 +62,23 @@ ZXYStream.prototype._read = function() {
         } else {
             lines += toLine(row);
         }
+
+        // if we hit the max number of tiles to analyze, push the lines
+        // already gathered and signal the end of the stream
+        if (stream.maxTilesCount > stream.maxTiles) {
+            if (lines) stream.push(lines);
+            stream.statement.finalize();
+            stream.push(null);
+            return;
+        }
+
         if (!--remaining) {
             if (error) {
                 stream.emit('error', error);
             } else {
-                if (lines) stream.push(lines);
-                else {
+                if (lines) {
+                  stream.push(lines);
+                } else {
                     stream.statement.finalize();
                     stream.push(null);
                 }


### PR DESCRIPTION
In order to back out of the ZXYReadStream in mapbox-geostats (which uses node-mbtiles) we need to `stream.push(null)` at the proper time. Here's my attempt to add some counters to the `._read` method.

Having trouble working around the batch, but I think this should work. Am I on the right track here?

cc @rclark @yhahn @springmeyer 