### PR TITLE
Correct scheme from tms to xyz

### DIFF
--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -224,7 +224,7 @@ MBTiles.prototype.getInfo = function(callback) {
 
     var mbtiles = this;
     var info = {};
-    info.scheme = 'tms';
+    info.scheme = 'xyz';
     info.basename = path.basename(mbtiles.filename);
     info.id = path.basename(mbtiles.filename, path.extname(mbtiles.filename));
     info.filesize = mbtiles._stat.size;


### PR DESCRIPTION
mbtiles stores tiles with tms scheme, but serve tiles with xyz scheme. `getTile` interface has flipped Y, so I thought the scheme should be `xyz`