### PR TITLE
Update sqlite3 dependency to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "url": "http://github.com/mapbox/node-mbtiles",
   "author": "Mapbox (https://www.mapbox.com)",
   "keywords": [
-    "map", 
+    "map",
     "mbtiles"
   ],
   "licenses": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Utilities and tilelive integration for the MBTiles format.",
   "url": "http://github.com/mapbox/node-mbtiles",
   "author": "Mapbox (https://www.mapbox.com)",
-  "keywords": ["map", "mbtiles"],
+  "keywords": [
+    "map", 
+    "mbtiles"
+  ],
   "licenses": [
     {
       "type": "BSD"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "Utilities and tilelive integration for the MBTiles format.",
   "url": "http://github.com/mapbox/node-mbtiles",
   "author": "Mapbox (https://www.mapbox.com)",
-  "keywords": [
-    "map",
-    "mbtiles"
-  ],
+  "keywords": ["map", "mbtiles"],
   "licenses": [
     {
       "type": "BSD"
@@ -30,7 +27,7 @@
   "dependencies": {
     "d3-queue": "~2.0.3",
     "@mapbox/tiletype": "0.3.x",
-    "sqlite3": "3.x",
+    "sqlite3": "4.x",
     "@mapbox/sphericalmercator": "~1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
sqlite3 3.x was causing a fallback build failure on Node 10 (Arch Linux, latest all the things). Switching to sqlite3 4.x solves the problem. All tests are passing and it seems to work fine, though my use case is limited to `getTile`.

Last two commits were to fix Prettier being overly judgmental on package.json.