### PR TITLE
collect stats for tif files

### DIFF
--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -10,6 +10,17 @@ var sqlite3 = require('sqlite3');
 var tiletype = require('@mapbox/tiletype');
 var ZXYStream = require('./zxystream');
 var queue = require('d3-queue').queue;
+var os = require('os');
+
+if (process.env.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED) {
+    var stats = { max:0, total:0, count:0 };
+    process.on('exit', function() {
+        if (stats.count > 0) {
+            fs.writeFileSync(os.tmpdir() + '/tilelive-bridge-stats.json', JSON.stringify(stats));
+        }
+    });
+}
+
 
 function noop(err) {
     if (err) throw err;
@@ -160,6 +171,10 @@ MBTiles.prototype.getTile = function(z, x, y, callback) {
 
     var sql = 'SELECT tile_data FROM tiles WHERE zoom_level = ? AND tile_column = ? AND tile_row = ?';
     var mbtiles = this;
+    if (process.env.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED) {
+        stats && stats.count++;
+    }
+
     this._db.get(sql, z, x, y, function(err, row) {
         if ((!err && !row) || (err && err.errno == 1)) {
             return callback(new Error('Tile does not exist'));
@@ -266,10 +281,10 @@ MBTiles.prototype.getInfo = function(callback) {
                 break;
             }
         });
-        
+
         // Guarantee that we always return proper schema type, even if 'tms' is specified in metadata
         info.scheme = 'xyz';
-        
+
         ensureZooms(info, function(err, info) {
             if (err) return callback(err);
             ensureBounds(info, function(err, info) {

--- a/lib/mbtiles.js
+++ b/lib/mbtiles.js
@@ -171,9 +171,6 @@ MBTiles.prototype.getTile = function(z, x, y, callback) {
 
     var sql = 'SELECT tile_data FROM tiles WHERE zoom_level = ? AND tile_column = ? AND tile_row = ?';
     var mbtiles = this;
-    if (process.env.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED) {
-        stats && stats.count++;
-    }
 
     this._db.get(sql, z, x, y, function(err, row) {
         if ((!err && !row) || (err && err.errno == 1)) {
@@ -188,6 +185,14 @@ MBTiles.prototype.getTile = function(z, x, y, callback) {
             var headers = tiletype.headers(row.tile_data);
             headers['Last-Modified'] = new Date(mbtiles._stat.mtime).toUTCString();
             headers['ETag'] = mbtiles._stat.size + '-' + Number(mbtiles._stat.mtime);
+            if (process.env.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED) {
+                var tileDataLength = row.tile_data.length;
+                stats.count++;
+                stats.total = stats.total + (tileDataLength * 0.001);
+                if (stats.max < tileDataLength) {
+                    stats.max = tileDataLength;
+                }
+            }
             return callback(null, row.tile_data, headers);
         }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mbtiles",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Utilities and tilelive integration for the MBTiles format.",
   "url": "http://github.com/mapbox/node-mbtiles",
   "author": "Mapbox (https://www.mapbox.com)",


### PR DESCRIPTION
Using the same BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED environment variable to collect stats.

[TODO] we can fix that in a major release if necessary.

cc @mapsam 